### PR TITLE
Pip read changes

### DIFF
--- a/R/pip_read-write.R
+++ b/R/pip_read-write.R
@@ -7,32 +7,89 @@
 #'
 #' @param id Character. Artifact name (file name stem).
 #' @param dir Directory where artifact is stored.
-#' @param version Version selector:
-#'   * NULL or 0 → latest version
-#'   * negative integer → N versions back
-#'   * "select" / "pick" / "choose" → interactive menu
-#'   * "available" → list available versions (extension provided below)
-#'   * version-id character → load specific version
+#' @param version An integer or a quoted directive. Retrieve a specific version
+#' of an artifact. See details.
 #' @param verbose Whether to print status messages.
 #'
 #' @return The loaded R object.
+#'
+#' @details
+#' The `version` argument allows you to load specific versions:
+#'   * `NULL` (default): loads the most recent version available.
+#'   * Negative integer (e.g., `-1`) or zero (`0`): loads that number of versions
+#'     before the most recent version. So, if `0`, it loads the current
+#'     version, which is equivalent to `NULL`. If `-1`, it will load the version
+#'     right before the current one, `-2` loads two versions before, and so on.
+#'   * Positive numbers: Error.
+#'   * Character: treated as a specific version ID (e.g., "20250801T162739Z-d86e8").
+#'   * `"select"`, `"pick"`, or `"choose"`: displays an interactive menu to select from
+#'     available versions (only in interactive R sessions).
+#'   * `"available"`: loads a list of the versions availables product from `stamp::st_versions`
+#'     but with an added variable called `vintage` that indicates the order of the versions.
 #'
 #' @export
 pip_read <- function(
     id,
     dir = ".",
+    format = NULL,
     version = NULL,
-    format = "qs2",
     verbose = TRUE
 ) {
 
-  # Construct artifact path
-  file <- fs::path(dir, id, ext = format)
-
+  # Defenses
   if (!fs::dir_exists(dir)) {
-    cli::cli_abort("Artifact folder {.path {file}} does not exist.")
+    cli::cli_abort("Artifact folder {.path {dir}} does not exist.")
   }
 
+  # Initiate stamp
+  stamp::st_init(dir)
+
+  # Construct artifact path
+  file <- fs::path(dir, id)
+
+  if(is.null(format)){
+    format  <- fs::path_ext(file)
+  }
+
+  # Check if file exists when format is not attached
+  if(is.na(format) || identical(format, "")){
+
+    ext        <- tolower(stamp::st_formats())
+    files_tbl  <- fs::dir_info(dir, recurse = FALSE)
+    paths_ext  <- tolower(fs::path_ext(files_tbl$path))
+    all_paths  <- files_tbl$path[files_tbl$type == "file" & paths_ext %in% ext]
+    paths_base <- fs::path_file(fs::path_ext_remove(all_paths))
+    id_base <- fs::path_file(fs::path_ext_remove(id)) 
+    matched_paths <- all_paths[paths_base == id_base]
+
+    if (length(matched_paths) == 0L) {
+      cli::cli_abort(c(
+        x = "Artifact {.field {id}} not found in {.path {dir}}.",
+        i = "If the artifact is stored under a different name or format, pass the correct {.arg id} or use {.code format = NULL} to inspect available files."
+      ))
+    }
+
+    file_ext <- fs::path_ext(matched_paths)|> tolower()|> collapse::funique()
+
+    if(length(file_ext)==1){
+      file <- fs::path_ext_set(path = file, ext = file_ext)
+    }else{
+      cli::cli_abort(c(x = "Multiple formats found for artifact {.field {id}}: {.val {file_ext}}.", 
+      i = "Specify which format to load using the {.arg format} argument."))
+    }
+  }else{
+    # Change format to the one requested
+    file <- fs::path_ext_set(path = file, ext = format)
+  }
+
+   # Make sure file exists (use absolute path to be safe)
+  file_abs <- fs::path_abs(file)
+  if (!fs::file_exists(file_abs)) {
+    cli::cli_abort(c(
+      x = "File {.path {file_abs}} does not exist.",
+      i = "Try {.code format = NULL} to list available formats or verify the {.arg id}/{.arg dir} combination."
+    ))
+  }
   # List available versions
   if (identical(version, "available")) {
     vr <- stamp::st_versions(file)
@@ -42,14 +99,16 @@ pip_read <- function(
     return(vr[])
   }
 
-  if (verbose)
-    cli::cli_alert_info("Loading {.path {file}} (version = {.strong {version}})")
-
   # Protect against empty artifact
   vr <- stamp::st_versions(file)
 
   if (nrow(vr) == 0)
     cli::cli_abort("No version files found in {.path {file}}.")
+
+  if (verbose) {
+    ver_label <- if (is.null(version)) "latest" else as.character(version)
+    cli::cli_alert_info("Loading {.path {file}} (version = {.strong {ver_label}})")
+  }
 
   # Delegate loading to stamp
   stamp::st_load(file, version = version)
@@ -115,6 +174,9 @@ pip_write <- function(
 
   # determine file path
   file <- fs::path(dir, id, ext = format)
+
+  # Initiate stamp
+  stamp::st_init(dir)
 
   # declare st_path
   sp <- stamp::st_path(file, format = format)

--- a/R/pip_read-write.R
+++ b/R/pip_read-write.R
@@ -8,7 +8,7 @@
 #' @param id Character. Artifact name (file name stem).
 #' @param dir Directory where artifact is stored.
 #' @param version An integer or a quoted directive. Retrieve a specific version
-#' of an artifact. See details.
+#' of an artifact. See details in `pip_read`.
 #' @param verbose Whether to print status messages.
 #'
 #' @return The loaded R object.
@@ -59,7 +59,7 @@ pip_read <- function(
     paths_ext  <- tolower(fs::path_ext(files_tbl$path))
     all_paths  <- files_tbl$path[files_tbl$type == "file" & paths_ext %in% ext]
     paths_base <- fs::path_file(fs::path_ext_remove(all_paths))
-    id_base <- fs::path_file(fs::path_ext_remove(id)) 
+    id_base <- fs::path_file(fs::path_ext_remove(id))
     matched_paths <- all_paths[paths_base == id_base]
 
     if (length(matched_paths) == 0L) {
@@ -74,7 +74,7 @@ pip_read <- function(
     if(length(file_ext)==1){
       file <- fs::path_ext_set(path = file, ext = file_ext)
     }else{
-      cli::cli_abort(c(x = "Multiple formats found for artifact {.field {id}}: {.val {file_ext}}.", 
+      cli::cli_abort(c(x = "Multiple formats found for artifact {.field {id}}: {.val {file_ext}}.",
       i = "Specify which format to load using the {.arg format} argument."))
     }
   }else{
@@ -82,11 +82,10 @@ pip_read <- function(
     file <- fs::path_ext_set(path = file, ext = format)
   }
 
-   # Make sure file exists (use absolute path to be safe)
-  file_abs <- fs::path_abs(file)
-  if (!fs::file_exists(file_abs)) {
+  # Make sure file exists
+  if (!fs::file_exists(file)) {
     cli::cli_abort(c(
-      x = "File {.path {file_abs}} does not exist.",
+      x = "File {.path {file}} does not exist.",
       i = "Try {.code format = NULL} to list available formats or verify the {.arg id}/{.arg dir} combination."
     ))
   }
@@ -159,7 +158,7 @@ pip_write <- function(
     x,
     id,
     dir = ".",
-    format = "NULL",
+    format = "qs2",
     metadata = list(),
     code = NULL,
     ...

--- a/man/load_dlw_data.Rd
+++ b/man/load_dlw_data.Rd
@@ -70,14 +70,8 @@ available. This is the default.}
 
 \item{id_name}{id name of dlw data}
 
-\item{version}{Version selector:
-\itemize{
-\item NULL or 0 → latest version
-\item negative integer → N versions back
-\item "select" / "pick" / "choose" → interactive menu
-\item "available" → list available versions (extension provided below)
-\item version-id character → load specific version
-}}
+\item{version}{An integer or a quoted directive. Retrieve a specific version
+of an artifact. See details in \code{pip_read}.}
 
 \item{verbose}{logical. If TRUE display information. Default is option
 "pipload.verbose"}

--- a/man/load_pip_data.Rd
+++ b/man/load_pip_data.Rd
@@ -73,14 +73,8 @@ available. This is the default.}
 
 \item{where}{character: Either "release" or "master". Se details.}
 
-\item{version}{Version selector:
-\itemize{
-\item NULL or 0 → latest version
-\item negative integer → N versions back
-\item "select" / "pick" / "choose" → interactive menu
-\item "available" → list available versions (extension provided below)
-\item version-id character → load specific version
-}}
+\item{version}{An integer or a quoted directive. Retrieve a specific version
+of an artifact. See details in \code{pip_read}.}
 
 \item{verbose}{logical. If TRUE display information. Default is option
 "pipload.verbose"}

--- a/man/pip_read.Rd
+++ b/man/pip_read.Rd
@@ -4,21 +4,15 @@
 \alias{pip_read}
 \title{Read a versioned artifact saved with {stamp}}
 \usage{
-pip_read(id, dir = ".", version = NULL, format = "qs2", verbose = TRUE)
+pip_read(id, dir = ".", format = NULL, version = NULL, verbose = TRUE)
 }
 \arguments{
 \item{id}{Character. Artifact name (file name stem).}
 
 \item{dir}{Directory where artifact is stored.}
 
-\item{version}{Version selector:
-\itemize{
-\item NULL or 0 → latest version
-\item negative integer → N versions back
-\item "select" / "pick" / "choose" → interactive menu
-\item "available" → list available versions (extension provided below)
-\item version-id character → load specific version
-}}
+\item{version}{An integer or a quoted directive. Retrieve a specific version
+of an artifact. See details in \code{pip_read}.}
 
 \item{verbose}{Whether to print status messages.}
 }
@@ -29,4 +23,20 @@ The loaded R object.
 \code{pip_read()} loads an artifact written by \code{pip_write()}.
 It is a thin wrapper around \code{stamp::st_load()} and preserves
 all version semantics (negative versions, "select", etc.)
+}
+\details{
+The \code{version} argument allows you to load specific versions:
+\itemize{
+\item \code{NULL} (default): loads the most recent version available.
+\item Negative integer (e.g., \code{-1}) or zero (\code{0}): loads that number of versions
+before the most recent version. So, if \code{0}, it loads the current
+version, which is equivalent to \code{NULL}. If \code{-1}, it will load the version
+right before the current one, \code{-2} loads two versions before, and so on.
+\item Positive numbers: Error.
+\item Character: treated as a specific version ID (e.g., "20250801T162739Z-d86e8").
+\item \code{"select"}, \code{"pick"}, or \code{"choose"}: displays an interactive menu to select from
+available versions (only in interactive R sessions).
+\item \code{"available"}: loads a list of the versions availables product from \code{stamp::st_versions}
+but with an added variable called \code{vintage} that indicates the order of the versions.
+}
 }

--- a/man/pip_write.Rd
+++ b/man/pip_write.Rd
@@ -8,7 +8,7 @@ pip_write(
   x,
   id,
   dir = ".",
-  format = "NULL",
+  format = "qs2",
   metadata = list(),
   code = NULL,
   ...

--- a/tests/testthat/test-pip_read-write.R
+++ b/tests/testthat/test-pip_read-write.R
@@ -43,12 +43,18 @@ test_that("pip_write and pip_read work for latest version", {
   dir <- create_test_dir()
   res <- pip_read("x", dir = dir)
   expect_equal(res, 4:9)
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read returns previous versions by negative index", {
   dir <- create_test_dir()
   expect_equal(pip_read("x", dir = dir, version = -1), 1:10)
   expect_equal(pip_read("x", dir = dir, version = -2), 1:5)
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read returns available versions as a data.table with vintage", {
@@ -59,17 +65,26 @@ test_that("pip_read returns available versions as a data.table with vintage", {
   expect_true("vintage" %in% names(vers))
   expect_equal(vers$vintage[1], 0)
   expect_equal(vers$vintage[2], -1)
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read errors on positive version index", {
   dir <- create_test_dir()
   expect_error(pip_read("x", dir = dir, version = 1))
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read errors on missing artifact", {
   dir <- fs::path_temp()
   fs::dir_create(dir)
   expect_error(pip_read("not_a_file", dir = dir))
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 # -------------------------------
@@ -86,6 +101,9 @@ test_that("pip_write preserves metadata and code hash", {
   expect_true("metadata" %in% names(out))
   expect_true("foo" %in% names(out$metadata))
   expect_true("code_hash" %in% names(out$metadata))
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_write always creates a version ID", {
@@ -95,6 +113,9 @@ test_that("pip_write always creates a version ID", {
   out <- pip_write(letters, id = "z", dir = dir)
   expect_true(!is.null(out$version_id))
   expect_type(out$version_id, "character")
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read preserves content integrity and type", {
@@ -103,6 +124,9 @@ test_that("pip_read preserves content integrity and type", {
   res <- pip_read("x", dir = dir)
   expect_true(is.integer(res))
   expect_equal(res, 4:9)
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read works with specific version ID", {
@@ -111,12 +135,74 @@ test_that("pip_read works with specific version ID", {
   version_id <- vers$version_id[2]  # pick second version
   res <- pip_read("x", dir = dir, version = version_id)
   expect_equal(res, 1:10)
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 test_that("pip_read works with interactive 'select' in non-interactive session", {
   skip_if(interactive(), "Skip interactive selection test in non-interactive session")
   dir <- create_test_dir()
   expect_error(pip_read("x", dir = dir, version = "select"))
+  # clean up
+  fs::dir_delete(dir)
+})
+
+
+test_that("pip_read detects multiple formats and requires explicit format", {
+  dir <- fs::path_temp("pip_fmt_test")
+  fs::dir_create(dir)
+
+  # Write the same artifact in two different formats
+  pip_write(letters[1:3], id = "fmt_test", dir = dir, format = "qs2")
+  Sys.sleep(1)
+  pip_write(letters[4:6], id = "fmt_test", dir = dir, format = "rds")
+
+  # Without specifying format, pip_read should error because multiple formats exist
+  expect_error(pip_read("fmt_test", dir = dir))
+
+  # Specifying format should load the correct object
+  expect_equal(pip_read("fmt_test", dir = dir, format = "qs2"), letters[1:3])
+  expect_equal(pip_read("fmt_test", dir = dir, format = "rds"), letters[4:6])
+
+  # clean up
+  fs::dir_delete(dir)
+})
+
+
+test_that("pip_read auto-detects single existing format when id has no extension", {
+  dir <- fs::path_temp("pip_single_fmt_test")
+  fs::dir_create(dir)
+
+  # Write artifact in a single format (qs2)
+  pip_write(mtcars[1:3, ], id = "single_fmt", dir = dir, format = "qs2")
+
+  # Calling pip_read without format should auto-detect and load the qs2 file
+  res <- pip_read("single_fmt", dir = dir)
+  expect_true(is.data.frame(res) || is.data.table(res))
+  expect_equal(nrow(res), 3)
+
+  # clean up
+  fs::dir_delete(dir)
+})
+
+
+test_that("pip_read handles id with extension and respects explicit format", {
+  dir <- fs::path_temp("pip_id_ext_test")
+  fs::dir_create(dir)
+
+  # Write artifact with explicit extension
+  pip_write(iris[1:5, ], id = "with_ext", dir = dir, format = "qs2")
+
+  # When id includes the extension and format = NULL, it should load the file
+  res1 <- pip_read("with_ext.qs2", dir = dir, format = NULL)
+  expect_equal(nrow(res1), 5)
+
+  # If the caller requests a different format, it should error (file not found)
+  expect_error(pip_read("with_ext.qs2", dir = dir, format = "rds"))
+
+  # clean up
+  fs::dir_delete(dir)
 })
 
 # -------------------------------


### PR DESCRIPTION
I added some checks for the format at loading time when it is not provided or when there are more than one format saved with the same id. 
For pip_write I also changed the format to "qs2" because the tests are not passing because of an error in st_path. We need to check these later, but for now, it should work. 
Also, we need to still fix functions in `stamp` to be able to save and load with qs2 package. At the moment everything is going to the default that is qs even thought the extension is qs2