### PR TITLE
Feat/verbose arg data loaders

### DIFF
--- a/.cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md
+++ b/.cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md
@@ -1,0 +1,116 @@
+---
+date: 2026-06-04
+title: "Add verbose argument to data loading functions missing it"
+status: active
+scope: "Lightweight"
+brainstorm: null
+language: "R"
+estimated-effort: "small"
+tags: [verbose, UX, consistency]
+---
+
+# Plan: Add verbose argument to data loading functions missing it
+
+## Objective
+
+Audit all exported data loading functions in pipload and ensure each has a
+`verbose` argument defaulting to `getOption("pipload.verbose")`. Functions
+that currently lack it should gain a consistent `verbose` parameter and
+appropriate messaging.
+
+## Context
+
+The package convention is `verbose = getOption("pipload.verbose")` with
+`cli::cli_alert_info()` messages when `verbose == TRUE`. Most functions
+already follow this pattern. A few older or utility functions do not expose
+`verbose` — they are either deprecated or were added before the convention
+solidified.
+
+### Current state
+
+| Function | File | Has `verbose`? | Notes |
+|----------|------|:-:|---|
+| `load_pip_data` | load_pip_data.R | ✅ | `getOption("pipload.verbose")` |
+| `find_pip_data` | load_pip_data.R | ✅ | |
+| `load_pip_deflated_data` | load_pip_deflated_data.R | ✅ | |
+| `load_dlw_data` | load_dlw_data.R | ✅ | |
+| `find_dlw_data` | load_dlw_data.R | ✅ | |
+| `load_aux_data` | load_aux_data.R | ✅ | |
+| `pip_load_data` | pip_load_data.R | ✅ | (legacy) |
+| `pip_load_dlw` | pip_load_dlw.R | ✅ | (legacy) |
+| `pip_load_cache` | pip_load_cache.R | ✅ | |
+| `pip_find_data` | pip_find_data.R | ✅ | (legacy) |
+| `pip_find_dlw` | pip_find_dlw.R | ✅ | (legacy) |
+| `pip_load_results` | pip_load_results.R | ✅ | |
+| `pip_load_all_aux` | pip_load_all_aux.R | ✅ | Default `FALSE` (inconsistent) |
+| `pip_find_cache` | pip_find_cache.R | ❌ | No verbose at all |
+| `pip_load_dlw_inventory` | pip_load_dlw_inventory.R | ❌ | No verbose at all |
+| `load_dlw_gmd_inventory` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_dlw_gmd_log` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_gmd_valid_inv` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_gmd_valid_log` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_gmd_valid_report` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `pip_load_inventory` | pip_load_inventory.R | ❌ | Deprecated — skip |
+
+## Requirements
+
+| ID | Requirement | Source |
+|----|-------------|--------|
+| R1 | `pip_find_cache()` gains `verbose = getOption("pipload.verbose")` and emits an info message when filtering succeeds | user |
+| R2 | `pip_load_dlw_inventory()` gains `verbose = getOption("pipload.verbose")` and emits a loading message | user |
+| R3 | `pip_load_all_aux()` default for `verbose` is changed from `FALSE` to `getOption("pipload.verbose")` for consistency | user |
+| R4 | Five zero-arg DLW loaders (`load_dlw_gmd_inventory`, `load_dlw_gmd_log`, `load_gmd_valid_inv`, `load_gmd_valid_log`, `load_gmd_valid_report`) gain `verbose = getOption("pipload.verbose")` | user |
+| R5 | Deprecated functions (`pip_load_inventory`) are left unchanged | user |
+
+## Implementation Steps
+
+### 1. Add `verbose` to `pip_find_cache()`
+- **Requirements**: R1
+- **Files**: `R/pip_find_cache.R`
+- **Details**: Add `verbose = getOption("pipload.verbose")` parameter. Add a `cli::cli_alert_info()` after the filtering step reporting how many rows matched.
+- **Tests**: Verify function still returns correct results; test that `verbose = FALSE` suppresses messages.
+- **Acceptance criteria**: `pip_find_cache(verbose = TRUE)` emits a cli message; `verbose = FALSE` is silent.
+
+### 2. Add `verbose` to `pip_load_dlw_inventory()`
+- **Requirements**: R2
+- **Files**: `R/pip_load_dlw_inventory.R`
+- **Details**: Add `verbose = getOption("pipload.verbose")` parameter. Emit a `cli::cli_alert_info("Loading DLW inventory from {.path {dlw_inv_file}}")` when loading.
+- **Tests**: Verify existing behavior is unchanged; test that message appears/disappears with flag.
+- **Acceptance criteria**: Function loads inventory with optional info message.
+
+### 3. Add `verbose` to five zero-arg DLW loaders
+- **Requirements**: R4
+- **Files**: `R/load_dlw_data.R`
+- **Details**: For each of `load_dlw_gmd_inventory`, `load_dlw_gmd_log`, `load_gmd_valid_inv`, `load_gmd_valid_log`, `load_gmd_valid_report`: add `verbose = getOption("pipload.verbose")` parameter and emit `cli::cli_alert_info("Loading {.field <artifact>}")` before the `pip_read()` call when `verbose == TRUE`.
+- **Tests**: Verify each function still returns correct results; verbose flag controls messaging.
+- **Acceptance criteria**: All five functions accept `verbose` and emit info messages when TRUE.
+
+### 4. Align `pip_load_all_aux()` default
+- **Requirements**: R3
+- **Files**: `R/pip_load_all_aux.R`
+- **Details**: Change `verbose = FALSE` to `verbose = getOption("pipload.verbose")`.
+- **Tests**: Ensure no regressions in existing tests.
+- **Acceptance criteria**: Default is now option-driven like the rest of the package.
+
+## Testing Strategy
+
+- Existing tests should continue to pass.
+- Manual interactive check: set `options(pipload.verbose = TRUE)` and call each function to confirm messages appear.
+- No new test files required for a lightweight change; add inline `expect_message`/`expect_no_message` if the test infrastructure supports it.
+
+## Documentation Checklist
+- [x] Function documentation (roxygen2 `@param verbose` already inherited in most — add explicit `@param` where added)
+- [ ] No README updates needed
+- [ ] No inline comments needed
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Changing `pip_load_all_aux` default from `FALSE` to option-driven may surprise callers expecting silence | The package option defaults to `TRUE` interactively, but pipelines should set the option explicitly; this is the documented convention |
+
+## Out of Scope
+
+- Refactoring message content or switching to a logging framework.
+- Adding `verbose` to deprecated functions.
+- Adding `verbose` to non-data-loading utilities (e.g., `pip_create_globals`).

--- a/.cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md
+++ b/.cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md
@@ -9,6 +9,8 @@ estimated-effort: "small"
 tags: [verbose, UX, consistency]
 supersedes: ".cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md"
 review-findings: [P2.1-cascade-amplification, P2.2-pip-read-threading, P3.1-inheritParams, P3.2-testing-hedge, P3.3-legacy-guard]
+completed-phases: [1]
+current-phase: 2
 ---
 
 # Plan: Add verbose argument to data loading functions missing it (v2)

--- a/.cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md
+++ b/.cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md
@@ -1,7 +1,8 @@
 ---
 date: 2026-06-05
 title: "Add verbose argument to data loading functions missing it (v2)"
-status: active
+status: completed
+completed-date: 2026-06-05
 scope: "Lightweight"
 brainstorm: null
 language: "R"
@@ -9,8 +10,7 @@ estimated-effort: "small"
 tags: [verbose, UX, consistency]
 supersedes: ".cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md"
 review-findings: [P2.1-cascade-amplification, P2.2-pip-read-threading, P3.1-inheritParams, P3.2-testing-hedge, P3.3-legacy-guard]
-completed-phases: [1]
-current-phase: 2
+completed-phases: [1, 2]
 ---
 
 # Plan: Add verbose argument to data loading functions missing it (v2)

--- a/.cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md
+++ b/.cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md
@@ -1,0 +1,159 @@
+---
+date: 2026-06-05
+title: "Add verbose argument to data loading functions missing it (v2)"
+status: active
+scope: "Lightweight"
+brainstorm: null
+language: "R"
+estimated-effort: "small"
+tags: [verbose, UX, consistency]
+supersedes: ".cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md"
+review-findings: [P2.1-cascade-amplification, P2.2-pip-read-threading, P3.1-inheritParams, P3.2-testing-hedge, P3.3-legacy-guard]
+---
+
+# Plan: Add verbose argument to data loading functions missing it (v2)
+
+## Objective
+
+Audit all exported data loading functions in pipload and ensure each has a
+`verbose` argument defaulting to `getOption("pipload.verbose")`. Functions
+that currently lack it should gain a consistent `verbose` parameter and
+appropriate messaging. The `verbose` value must be threaded through the entire
+call stack (including `pip_read()`) so that `verbose = FALSE` guarantees
+silence.
+
+## Context
+
+The package convention is `verbose = getOption("pipload.verbose")` with
+`cli::cli_alert_info()` messages when `verbose == TRUE`. Most functions
+already follow this pattern. A few older or utility functions do not expose
+`verbose` — they are either deprecated or were added before the convention
+solidified.
+
+`pip_read()` already accepts `verbose` and forwards it to `stamp::st_load()`.
+Any function calling `pip_read()` must pass its own `verbose` value through to
+ensure callers get consistent silence when they request it.
+
+### Revision notes (from plan review)
+
+- **P2.1**: `pip_load_all_aux` cascades `verbose` into `pip_load_aux()` inside
+  a loop. Changing the default from `FALSE` to `getOption("pipload.verbose")`
+  means N messages fire interactively (one per aux). This is intentional —
+  document it and add a loop-level test.
+- **P2.2**: The five lambda functions must pass `verbose = verbose` to
+  `pip_read()` to ensure end-to-end silence when `verbose = FALSE`.
+- **P3.1**: `pip_find_cache` inherits `@param verbose` from `pip_load_cache`
+  via `@inheritParams` — no explicit `@param` needed.
+- **P3.2**: Testing strategy is definitive — `expect_message()` /
+  `expect_no_message()` tests are required, not optional.
+- **P3.3**: `pip_load_dlw_inventory` uses legacy globals; note it as
+  provisional pending possible deprecation.
+
+### Current state
+
+| Function | File | Has `verbose`? | Notes |
+|----------|------|:-:|---|
+| `load_pip_data` | load_pip_data.R | ✅ | `getOption("pipload.verbose")` |
+| `find_pip_data` | load_pip_data.R | ✅ | |
+| `load_pip_deflated_data` | load_pip_deflated_data.R | ✅ | |
+| `load_dlw_data` | load_dlw_data.R | ✅ | |
+| `find_dlw_data` | load_dlw_data.R | ✅ | |
+| `load_aux_data` | load_aux_data.R | ✅ | |
+| `pip_load_data` | pip_load_data.R | ✅ | (legacy) |
+| `pip_load_dlw` | pip_load_dlw.R | ✅ | (legacy) |
+| `pip_load_cache` | pip_load_cache.R | ✅ | |
+| `pip_find_data` | pip_find_data.R | ✅ | (legacy) |
+| `pip_find_dlw` | pip_find_dlw.R | ✅ | (legacy) |
+| `pip_load_results` | pip_load_results.R | ✅ | |
+| `pip_load_all_aux` | pip_load_all_aux.R | ✅ | Default `FALSE` (inconsistent) |
+| `pip_find_cache` | pip_find_cache.R | ❌ | No verbose at all |
+| `pip_load_dlw_inventory` | pip_load_dlw_inventory.R | ❌ | No verbose; legacy globals pattern (provisional) |
+| `load_dlw_gmd_inventory` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_dlw_gmd_log` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_gmd_valid_inv` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_gmd_valid_log` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `load_gmd_valid_report` | load_dlw_data.R | ❌ | Zero-arg lambda, no verbose |
+| `pip_load_inventory` | pip_load_inventory.R | ❌ | Deprecated — skip |
+
+## Requirements
+
+| ID | Requirement | Source |
+|----|-------------|--------|
+| R1 | `pip_find_cache()` gains `verbose = getOption("pipload.verbose")` and emits an info message when filtering succeeds | user |
+| R2 | `pip_load_dlw_inventory()` gains `verbose = getOption("pipload.verbose")` and emits a loading message (provisional — may be deprecated) | user |
+| R3 | `pip_load_all_aux()` default for `verbose` changes from `FALSE` to `getOption("pipload.verbose")` | user |
+| R4 | Five zero-arg DLW loaders gain `verbose = getOption("pipload.verbose")` and thread it to `pip_read()` | user + P2.2 |
+| R5 | All modified functions pass `verbose` through to downstream calls (`pip_read()`, `pip_load_aux()`) — no silent leaks | P2.2 |
+| R6 | Deprecated functions (`pip_load_inventory`) are left unchanged | user |
+
+## Implementation Steps
+
+## Phase 1: Core implementation
+
+### 1. Add `verbose` to `pip_find_cache()`
+- **Requirements**: R1
+- **Files**: `R/pip_find_cache.R`
+- **Details**: Add `verbose = getOption("pipload.verbose")` parameter. Add a `cli::cli_alert_info()` after the filtering step reporting how many rows matched.
+- **Documentation**: No explicit `@param verbose` needed — `@inheritParams pip_load_cache` already provides it (P3.1).
+- **Acceptance criteria**: `pip_find_cache(verbose = TRUE)` emits a cli message; `verbose = FALSE` is silent.
+
+### 2. Add `verbose` to `pip_load_dlw_inventory()` (provisional)
+- **Requirements**: R2
+- **Files**: `R/pip_load_dlw_inventory.R`
+- **Details**: Add `verbose = getOption("pipload.verbose")` parameter. Emit `cli::cli_alert_info("Loading DLW inventory from {.path {dlw_inv_file}}")` when loading. Note: this function uses legacy `pip_create_globals()` globals and may be deprecated when the pipeline migration completes (P3.3).
+- **Acceptance criteria**: Function loads inventory with optional info message.
+
+### 3. Add `verbose` to five zero-arg DLW loaders and thread to `pip_read()`
+- **Requirements**: R4, R5
+- **Files**: `R/load_dlw_data.R`
+- **Details**: For each of `load_dlw_gmd_inventory`, `load_dlw_gmd_log`, `load_gmd_valid_inv`, `load_gmd_valid_log`, `load_gmd_valid_report`:
+  1. Change `\()` to `\(verbose = getOption("pipload.verbose"))`.
+  2. Add `cli::cli_alert_info("Loading {.field <artifact>}")` gated on `if (verbose)`.
+  3. Pass `verbose = verbose` to the `pip_read()` call so that `pip_read()`'s own message and `stamp::st_load()` both respect the flag.
+- **Documentation**: These share `@rdname load_dlw_data`; add a single `@param verbose logical. If TRUE display loading messages. Default is option "pipload.verbose"` to the shared block.
+- **Acceptance criteria**: `load_gmd_valid_inv(verbose = FALSE)` produces zero messages (neither from the function nor from `pip_read()`).
+
+### 4. Align `pip_load_all_aux()` default and document cascade
+- **Requirements**: R3, R5
+- **Files**: `R/pip_load_all_aux.R`
+- **Details**: Change `verbose = FALSE` to `verbose = getOption("pipload.verbose")`. The function already passes `verbose = verbose` to `pip_load_aux()` inside the loop (line ~125). **Cascade note** (P2.1): with the new default, interactive users will see one message per aux file loaded (currently 5 by default). This matches the behaviour of all other loaders and is the intended UX — pipelines should set `options(pipload.verbose = FALSE)` at session start.
+- **Acceptance criteria**: Default is option-driven; passing `verbose = FALSE` silences the entire loop.
+
+## Phase 2: Tests
+
+### 5. Add message tests for all modified functions
+- **Requirements**: R1–R5
+- **Files**: `tests/testthat/test-verbose-arg.R` (new)
+- **Details**: For each modified function, add paired tests:
+  - `expect_message(fn(verbose = TRUE), ...)` confirming cli output.
+  - `expect_no_message(fn(verbose = FALSE))` confirming full silence.
+  - For `pip_load_all_aux`: test with a length-2 `aux` vector to confirm multiple messages fire when verbose, and zero when not (P2.1 cascade coverage).
+  - Tests will need mocking (`local_mocked_bindings`) to avoid requiring real data connections.
+- **Acceptance criteria**: All tests pass under `devtools::test()`.
+
+## Testing Strategy
+
+- `expect_message()` for `verbose = TRUE` paths.
+- `expect_no_message()` for `verbose = FALSE` paths (end-to-end silence).
+- Mock external dependencies (`pipfun::get_pip_folders`, `stamp::st_alias_list`, `pip_read`) to run without a live pipeline connection.
+- Test `pip_load_all_aux` with loop length > 1 to cover the cascade amplification (P2.1).
+
+## Documentation Checklist
+- [x] Function documentation: `@param verbose` via `@inheritParams` where applicable; explicit where not inherited
+- [ ] No README updates needed
+- [ ] No inline comments needed beyond the cascade note in `pip_load_all_aux`
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Changing `pip_load_all_aux` default from `FALSE` to option-driven fires N messages interactively (P2.1) | This is intended UX — matches all other loaders. Pipelines must set `options(pipload.verbose = FALSE)`. Document in `?pip_load_all_aux`. |
+| `pip_load_dlw_inventory` may be deprecated soon (P3.3) | Mark as provisional in the plan. The verbose addition is trivial and doesn't block migration. |
+| Shared `@rdname load_dlw_data` block — adding `@param verbose` to all five lambdas at once | Add a single `@param verbose` in the shared documentation block (not per-function) to avoid duplication. |
+
+## Out of Scope
+
+- Refactoring message content or switching to a logging framework.
+- Adding `verbose` to deprecated functions.
+- Adding `verbose` to non-data-loading utilities (e.g., `pip_create_globals`).
+- Migrating `pip_load_dlw_inventory` to new pipeline structure.

--- a/.cg-docs/solutions/testing-patterns/2026-06-04-r-lambda-syntax-missed-by-function-regex.md
+++ b/.cg-docs/solutions/testing-patterns/2026-06-04-r-lambda-syntax-missed-by-function-regex.md
@@ -1,0 +1,74 @@
+---
+date: 2026-06-04
+title: "R lambda syntax `\\()` missed by `<- function` regex audits"
+category: "testing-patterns"
+language: "R"
+tags: [R, lambda, function-definition, regex, audit, grep, code-review]
+root-cause: "R supports two function-definition syntaxes; grep for `<- function` silently skips `\\()` lambdas"
+severity: "P3"
+---
+
+# R lambda syntax `\()` missed by `<- function` regex audits
+
+## Problem
+
+When auditing R source files for all exported or public function definitions
+(e.g. to check that every function has a `verbose` argument), a grep pattern
+like:
+
+```regex
+<- function
+```
+
+silently misses lambdas defined with the shorthand syntax introduced in R 4.1:
+
+```r
+load_gmd_valid_inv <- \() { ... }
+load_gmd_valid_log <- \(x, verbose = TRUE) { ... }
+```
+
+The result is an incomplete audit — functions appear to have been checked
+when they were not.
+
+## Root Cause
+
+R 4.1+ introduced `\(args) body` as a shorthand for `function(args) body`.
+Both forms are semantically identical and both appear in production code.
+A regex that only matches `function(` will never match `\(`.
+
+## Solution
+
+Use an alternation pattern that covers both syntaxes when auditing:
+
+```regex
+(<- function)|(<- \\()
+```
+
+In `grep_search` (VS Code tool):
+
+```
+query: "(<- function)|(<- \\()"
+isRegexp: true
+```
+
+In `grep` / `rg` on the command line:
+
+```bash
+rg "(<- function)|(<- \\()" R/
+```
+
+## Prevention
+
+- **Always use both patterns** when writing grep queries that enumerate
+  function definitions in an R codebase.
+- When reading a file to audit its public API, prefer reading the whole file
+  (or at least scanning to EOF) rather than relying on a regex to enumerate
+  functions — lambda definitions often appear at the bottom of a file after
+  the primary `function`-style definitions.
+- If writing a script to extract all exported functions from an R package,
+  parse `NAMESPACE` (which lists every export regardless of syntax) and then
+  locate definitions in source files.
+
+## Related
+
+- No direct existing solution cross-references.

--- a/R/load_dlw_data.R
+++ b/R/load_dlw_data.R
@@ -269,7 +269,7 @@ check_dlw_id_name <- \(id_name) {
 #' \dontrun{
 #' load_dlw_gmd_inventory()
 #' }
-load_dlw_gmd_inventory <- \() {
+load_dlw_gmd_inventory <- \(verbose = getOption("pipload.verbose")) {
   binv <- pipfun::get_pip_folders(folder = "dlw_inventory", verbose = FALSE)
 
   alias_list <- stamp::st_alias_list()
@@ -282,7 +282,8 @@ load_dlw_gmd_inventory <- \() {
     ))
   }
 
-  pip_read("dlw_gmd_inv", alias = alias)
+  if (verbose) cli::cli_alert_info("Loading {.field dlw_gmd_inv}")
+  pip_read("dlw_gmd_inv", alias = alias, verbose = verbose)
 }
 
 
@@ -294,7 +295,7 @@ load_dlw_gmd_inventory <- \() {
 #' \dontrun{
 #' load_dlw_gmd_log()
 #' }
-load_dlw_gmd_log <- \() {
+load_dlw_gmd_log <- \(verbose = getOption("pipload.verbose")) {
   binv <- pipfun::get_pip_folders(folder = "dlw_inventory", verbose = FALSE)
 
   alias_list <- stamp::st_alias_list()
@@ -307,7 +308,8 @@ load_dlw_gmd_log <- \() {
     ))
   }
 
-  pip_read("dlw_gmd_log", alias = alias)
+  if (verbose) cli::cli_alert_info("Loading {.field dlw_gmd_log}")
+  pip_read("dlw_gmd_log", alias = alias, verbose = verbose)
 }
 
 #' @returns [load_gmd_valid_inv] data.table with inventory of validated GMD data
@@ -318,7 +320,7 @@ load_dlw_gmd_log <- \() {
 #' \dontrun{
 #' load_gmd_valid_inv()
 #' }
-load_gmd_valid_inv <- \() {
+load_gmd_valid_inv <- \(verbose = getOption("pipload.verbose")) {
   binv <- pipfun::get_pip_folders(folder = "dlw_metadata", verbose = FALSE)
 
   alias_list <- stamp::st_alias_list()
@@ -331,7 +333,8 @@ load_gmd_valid_inv <- \() {
     ))
   }
 
-  pip_read("gmd_valid_inv", alias = alias)
+  if (verbose) cli::cli_alert_info("Loading {.field gmd_valid_inv}")
+  pip_read("gmd_valid_inv", alias = alias, verbose = verbose)
 }
 
 #' @returns [load_gmd_valid_log] data.table with log of GMD validated workflow
@@ -342,7 +345,7 @@ load_gmd_valid_inv <- \() {
 #' \dontrun{
 #' load_gmd_valid_log()
 #' }
-load_gmd_valid_log <- \() {
+load_gmd_valid_log <- \(verbose = getOption("pipload.verbose")) {
   binv <- pipfun::get_pip_folders(folder = "dlw_metadata", verbose = FALSE)
 
   alias_list <- stamp::st_alias_list()
@@ -355,7 +358,8 @@ load_gmd_valid_log <- \() {
     ))
   }
 
-  pip_read("dlw_validation_log", alias = alias)
+  if (verbose) cli::cli_alert_info("Loading {.field dlw_validation_log}")
+  pip_read("dlw_validation_log", alias = alias, verbose = verbose)
 }
 
 #' @returns [load_gmd_valid_report] data.table with validation report data
@@ -366,7 +370,7 @@ load_gmd_valid_log <- \() {
 #' \dontrun{
 #' load_gmd_valid_report()
 #' }
-load_gmd_valid_report <- \() {
+load_gmd_valid_report <- \(verbose = getOption("pipload.verbose")) {
   binv <- pipfun::get_pip_folders(folder = "dlw_metadata", verbose = FALSE)
 
   alias_list <- stamp::st_alias_list()
@@ -379,5 +383,6 @@ load_gmd_valid_report <- \() {
     ))
   }
 
-  pip_read("validation_report", alias = alias)
+  if (verbose) cli::cli_alert_info("Loading {.field validation_report}")
+  pip_read("validation_report", alias = alias, verbose = verbose)
 }

--- a/R/pip_find_cache.R
+++ b/R/pip_find_cache.R
@@ -11,19 +11,19 @@
 #' \dontrun{
 #' pip_find_cache()
 #' }
-pip_find_cache <- function(country          = NULL,
-                           year             = NULL,
-                           survey_acronym   = NULL,
-                           data_level       = NULL,
-                           welfare_type     = NULL,
-                           source           = NULL,
-                           version          = NULL,
-                           tool             = c("PC", "pc", "tb", "TB"),
-                           verbose          = getOption("pipload.verbose"),
-                           root_dir         = Sys.getenv("PIP_ROOT_DIR"),
-                           pipedir          = pipfun::pip_create_globals(root_dir)$PIP_PIPE_DIR
-                           )  {
-
+pip_find_cache <- function(
+  country = NULL,
+  year = NULL,
+  survey_acronym = NULL,
+  data_level = NULL,
+  welfare_type = NULL,
+  source = NULL,
+  version = NULL,
+  tool = c("PC", "pc", "tb", "TB"),
+  root_dir = Sys.getenv("PIP_ROOT_DIR"),
+  pipedir = pipfun::pip_create_globals(root_dir)$PIP_PIPE_DIR,
+  verbose = getOption("pipload.verbose")
+) {
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   #                   Check parameters   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,63 +35,64 @@ pip_find_cache <- function(country          = NULL,
     wt_ok <- any(toupper(welfare_type) %in% c("CON", "INC"))
 
     if (isFALSE(wt_ok)) {
-      cli::cli_alert_danger("{.code welfare_type} must be either {.field CON} or
-                            {.field INC}, not {.field {welfare_type}}", wrap = TRUE)
-      msg     <- "wrong specification in `welfare_type`"
-      rlang::abort(c(msg),class = "pipload_error")
+      cli::cli_alert_danger(
+        "{.code welfare_type} must be either {.field CON} or
+                            {.field INC}, not {.field {welfare_type}}",
+        wrap = TRUE
+      )
+      msg <- "wrong specification in `welfare_type`"
+      rlang::abort(c(msg), class = "pipload_error")
     }
-
   }
 
-  ri <- pip_load_cache_inventory(pipedir = pipedir,
-                                 tool    = tool,
-                                 version = version)
+  ri <- pip_load_cache_inventory(
+    pipedir = pipedir,
+    tool = tool,
+    version = version
+  )
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ##           Create regex --------
 
-  args <- c("country",
-            "year",
-            "survey_acronym",
-            "data_level",
-            "welfare_type",
-            "source")
+  args <- c(
+    "country",
+    "year",
+    "survey_acronym",
+    "data_level",
+    "welfare_type",
+    "source"
+  )
 
-
-  Tcountry          = "[A-Z]{3}"
-  Tyear             = "[0-9]{4}"
-  Tsurvey_acronym   = "[0-9A-Z\\-]+"
-  Tdata_level       = "D[123]"
-  Twelfare_type     = "(CON|INC)"
-  Tsource           = "[A-Z]+$"
+  Tcountry = "[A-Z]{3}"
+  Tyear = "[0-9]{4}"
+  Tsurvey_acronym = "[0-9A-Z\\-]+"
+  Tdata_level = "D[123]"
+  Twelfare_type = "(CON|INC)"
+  Tsource = "[A-Z]+$"
 
   pattern <- vector(length = length(args))
   for (i in seq_along(args)) {
-    x  <- args[i]
+    x <- args[i]
     tx <- paste0("T", x)
 
     if (is.null(get(x))) {
-
       pattern[i] <- get(tx)
-
     } else {
-
-      y <-  paste0("(", paste(get(x), collapse = "|"), ")")
+      y <- paste0("(", paste(get(x), collapse = "|"), ")")
       pattern[i] <- y
     }
-
   } # end of loop
 
   pattern <- paste(pattern, collapse = "_")
   pattern <- paste0("^", pattern)
 
-  ri <- ri[grepl(pattern, cache_id),
-           cache_id]
+  ri <- ri[grepl(pattern, cache_id), cache_id]
 
   if (verbose) {
-    cli::cli_alert_info("Found {.val {length(ri)}} cache file{?s} matching the filter.")
+    cli::cli_alert_info(
+      "Found {.val {length(ri)}} cache file{?s} matching the filter."
+    )
   }
 
   return(ri)
-
 }

--- a/R/pip_find_cache.R
+++ b/R/pip_find_cache.R
@@ -19,6 +19,7 @@ pip_find_cache <- function(country          = NULL,
                            source           = NULL,
                            version          = NULL,
                            tool             = c("PC", "pc", "tb", "TB"),
+                           verbose          = getOption("pipload.verbose"),
                            root_dir         = Sys.getenv("PIP_ROOT_DIR"),
                            pipedir          = pipfun::pip_create_globals(root_dir)$PIP_PIPE_DIR
                            )  {
@@ -86,6 +87,10 @@ pip_find_cache <- function(country          = NULL,
 
   ri <- ri[grepl(pattern, cache_id),
            cache_id]
+
+  if (verbose) {
+    cli::cli_alert_info("Found {.val {length(ri)}} cache file{?s} matching the filter.")
+  }
 
   return(ri)
 

--- a/R/pip_load_all_aux.R
+++ b/R/pip_load_all_aux.R
@@ -23,7 +23,7 @@ pip_load_all_aux <- function(replace           = NULL,
                              maindir           = pipfun::pip_create_globals(root_dir)$PIP_DATA_DIR,
                              version           = NULL,
                              apply_label       = TRUE,
-                             verbose           = FALSE,
+                             verbose           = getOption("pipload.verbose"),
                              preferred_format  = NULL
                              ) {
 

--- a/R/pip_load_dlw_inventory.R
+++ b/R/pip_load_dlw_inventory.R
@@ -5,6 +5,7 @@
 #' the dlw inventory is updated
 #'
 #' @param dlw_dir character: path of datalibweb raw data
+#' @param verbose logical: If TRUE, display loading messages. Default is option "pipload.verbose"
 #' @inheritParams pip_create_globals
 #'
 #' @return data.table
@@ -14,7 +15,8 @@
 #' pip_load_dlw_inventory()
 pip_load_dlw_inventory  <- function(
   root_dir = Sys.getenv("PIP_ROOT_DIR"),
-  dlw_dir  = pipfun::pip_create_globals(root_dir)$DLW_RAW_DIR
+  dlw_dir  = pipfun::pip_create_globals(root_dir)$DLW_RAW_DIR,
+  verbose  = getOption("pipload.verbose")
   ){
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,6 +42,10 @@ pip_load_dlw_inventory  <- function(
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # load data   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  if (verbose) {
+    cli::cli_alert_info("Loading DLW inventory from {.path {dlw_inv_file}}")
+  }
 
   dlw_inv <-fst::read_fst(dlw_inv_file,
                           as.data.table = TRUE)

--- a/compound-gpid.context.md
+++ b/compound-gpid.context.md
@@ -42,6 +42,16 @@ absent-field, and any future early-return). See
 - `DESCRIPTION` must end with a trailing newline.
 - See `.cg-docs/solutions/build-errors/2026-05-28-rcmd-check-rd-param-mismatches.md`.
 
+### R function-definition audit: always match both `function` and `\()` syntaxes
+
+When grepping R source for function definitions (e.g. to audit parameter
+coverage), always use the alternation pattern `(<- function)|(<- \\()`.
+The `\()` lambda shorthand (R 4.1+) is semantically identical to
+`function()` but is **silently missed** by `<- function`-only patterns.
+As a fallback, parse `NAMESPACE` to enumerate all exports and then locate
+their definitions. See
+`.cg-docs/solutions/testing-patterns/2026-06-04-r-lambda-syntax-missed-by-function-regex.md`.
+
 ### testthat: always chain expect_error() after expect_warning() when the function can also error
 
 `expect_warning()` muffles the warning but re-throws any subsequent error.

--- a/man/load_dlw_data.Rd
+++ b/man/load_dlw_data.Rd
@@ -37,15 +37,15 @@ find_dlw_data(
 
 check_dlw_id_name(id_name)
 
-load_dlw_gmd_inventory()
+load_dlw_gmd_inventory(verbose = getOption("pipload.verbose"))
 
-load_dlw_gmd_log()
+load_dlw_gmd_log(verbose = getOption("pipload.verbose"))
 
-load_gmd_valid_inv()
+load_gmd_valid_inv(verbose = getOption("pipload.verbose"))
 
-load_gmd_valid_log()
+load_gmd_valid_log(verbose = getOption("pipload.verbose"))
 
-load_gmd_valid_report()
+load_gmd_valid_report(verbose = getOption("pipload.verbose"))
 }
 \arguments{
 \item{country_code}{Character: country ISO 3 code.}

--- a/man/pip_find_cache.Rd
+++ b/man/pip_find_cache.Rd
@@ -14,7 +14,8 @@ pip_find_cache(
   version = NULL,
   tool = c("PC", "pc", "tb", "TB"),
   root_dir = Sys.getenv("PIP_ROOT_DIR"),
-  pipedir = pipfun::pip_create_globals(root_dir)$PIP_PIPE_DIR
+  pipedir = pipfun::pip_create_globals(root_dir)$PIP_PIPE_DIR,
+  verbose = getOption("pipload.verbose")
 )
 }
 \arguments{
@@ -43,6 +44,8 @@ income}
 
 \item{pipedir}{charater: directory of pipeline. Default is
 \code{pipfun::pip_create_globals(root_dir)$PIP_PIPE_DIR}}
+
+\item{verbose}{logical: If TRUE, display informative messages. Default TRUE}
 }
 \value{
 data.table

--- a/man/pip_find_dlw.Rd
+++ b/man/pip_find_dlw.Rd
@@ -54,7 +54,7 @@ in the Poverty Calculator. Default if FALSE}
 \item{filter_to_tb}{logical: If TRUE filter most recent data to be included
 in the Table Maker. Default if FALSE}
 
-\item{verbose}{logical: whether to display message. Default is TRUE}
+\item{verbose}{logical: If TRUE, display loading messages. Default is option "pipload.verbose"}
 }
 \value{
 data.frame: list of filenames to be loaded with pcn_load()

--- a/man/pip_load_all_aux.Rd
+++ b/man/pip_load_all_aux.Rd
@@ -14,7 +14,7 @@ pip_load_all_aux(
   maindir = pipfun::pip_create_globals(root_dir)$PIP_DATA_DIR,
   version = NULL,
   apply_label = TRUE,
-  verbose = FALSE,
+  verbose = getOption("pipload.verbose"),
   preferred_format = NULL
 )
 }

--- a/man/pip_load_dlw_inventory.Rd
+++ b/man/pip_load_dlw_inventory.Rd
@@ -6,13 +6,16 @@
 \usage{
 pip_load_dlw_inventory(
   root_dir = Sys.getenv("PIP_ROOT_DIR"),
-  dlw_dir = pipfun::pip_create_globals(root_dir)$DLW_RAW_DIR
+  dlw_dir = pipfun::pip_create_globals(root_dir)$DLW_RAW_DIR,
+  verbose = getOption("pipload.verbose")
 )
 }
 \arguments{
 \item{root_dir}{character: root directory of the PIP data}
 
 \item{dlw_dir}{character: path of datalibweb raw data}
+
+\item{verbose}{logical: If TRUE, display loading messages. Default is option "pipload.verbose"}
 }
 \value{
 data.table

--- a/roadmap.json
+++ b/roadmap.json
@@ -34,8 +34,8 @@
                 {
                     "id": "verbose-arg-data-loaders",
                     "title": "Check if data loading functions have verbose argument",
-                    "status": "planned",
-                    "plan": ".cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md"
+                    "status": "active",
+                    "plan": ".cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md"
                 },
                 {
                     "id": "audit-deprecate-legacy-loaders",

--- a/roadmap.json
+++ b/roadmap.json
@@ -30,6 +30,18 @@
                     "title": "Pre-flatten metadata into a single summary qs2 artifact at pipeline write-time",
                     "status": "idea",
                     "plan": null
+                },
+                {
+                    "id": "verbose-arg-data-loaders",
+                    "title": "Check if data loading functions have verbose argument",
+                    "status": "planned",
+                    "plan": ".cg-docs/plans/2026-06-04-verbose-arg-data-loaders.md"
+                },
+                {
+                    "id": "audit-deprecate-legacy-loaders",
+                    "title": "Audit legacy loading functions and deprecate those superseded by new pipeline",
+                    "status": "idea",
+                    "plan": null
                 }
             ]
         }

--- a/roadmap.json
+++ b/roadmap.json
@@ -34,7 +34,7 @@
                 {
                     "id": "verbose-arg-data-loaders",
                     "title": "Check if data loading functions have verbose argument",
-                    "status": "active",
+                    "status": "done",
                     "plan": ".cg-docs/plans/2026-06-05-verbose-arg-data-loaders-v2.md"
                 },
                 {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,7 @@
+# Helpers available to all test files (sourced by testthat before any tests run).
+
+#' Returns TRUE when PIP_ROOT_DIR is set and the auxiliary data directory exists.
+has_pip_data <- function() {
+  root_dir <- Sys.getenv("PIP_ROOT_DIR", "")
+  nzchar(root_dir) && dir.exists(file.path(root_dir, "_aux"))
+}

--- a/tests/testthat/test-load_pip_deflated_data.R
+++ b/tests/testthat/test-load_pip_deflated_data.R
@@ -197,6 +197,10 @@ test_that("load_pip_deflated_data() integration: load → deflate round-trip", {
   skip_if_not_installed("pipdata")
   skip_if_not_installed("pipfun")
   skip_on_ci()
+  skip_if_not(
+    has_pip_data(),
+    "PIP auxiliary data not accessible in test environment"
+  )
 
   lr <- pipfun::get_latest_pip_release()
   # Note: pipfun has no teardown_working_release() export; side-effects

--- a/tests/testthat/test-verbose-arg.R
+++ b/tests/testthat/test-verbose-arg.R
@@ -1,12 +1,6 @@
 library(testthat)
 library(data.table)
 
-# Skip tests if PIP data is not accessible
-has_pip_data <- function() {
-  root_dir <- Sys.getenv("PIP_ROOT_DIR", "")
-  nzchar(root_dir) && dir.exists(file.path(root_dir, "_aux"))
-}
-
 # -------------------------------------------------------------------------
 # pip_find_cache()
 # -------------------------------------------------------------------------

--- a/tests/testthat/test-verbose-arg.R
+++ b/tests/testthat/test-verbose-arg.R
@@ -1,6 +1,12 @@
 library(testthat)
 library(data.table)
 
+# Skip tests if PIP data is not accessible
+has_pip_data <- function() {
+  root_dir <- Sys.getenv("PIP_ROOT_DIR", "")
+  nzchar(root_dir) && dir.exists(file.path(root_dir, "_aux"))
+}
+
 # -------------------------------------------------------------------------
 # pip_find_cache()
 # -------------------------------------------------------------------------
@@ -80,6 +86,7 @@ test_that("pip_load_dlw_inventory is silent when verbose = FALSE", {
 
 test_that("load_dlw_gmd_inventory accepts verbose and emits message when TRUE", {
   expect_true("verbose" %in% names(formals(load_dlw_gmd_inventory)))
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -89,13 +96,18 @@ test_that("load_dlw_gmd_inventory accepts verbose and emits message when TRUE", 
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_message(load_dlw_gmd_inventory(verbose = TRUE), regexp = "dlw_gmd_inv")
+  expect_true(isTRUE(verbose_received))
 })
 
 test_that("load_dlw_gmd_inventory is silent when verbose = FALSE", {
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -105,14 +117,19 @@ test_that("load_dlw_gmd_inventory is silent when verbose = FALSE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_no_message(load_dlw_gmd_inventory(verbose = FALSE))
+  expect_false(isTRUE(verbose_received))
 })
 
 test_that("load_dlw_gmd_log accepts verbose and emits message when TRUE", {
   expect_true("verbose" %in% names(formals(load_dlw_gmd_log)))
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -122,13 +139,18 @@ test_that("load_dlw_gmd_log accepts verbose and emits message when TRUE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_message(load_dlw_gmd_log(verbose = TRUE), regexp = "dlw_gmd_log")
+  expect_true(isTRUE(verbose_received))
 })
 
 test_that("load_dlw_gmd_log is silent when verbose = FALSE", {
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -138,14 +160,19 @@ test_that("load_dlw_gmd_log is silent when verbose = FALSE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_no_message(load_dlw_gmd_log(verbose = FALSE))
+  expect_false(isTRUE(verbose_received))
 })
 
 test_that("load_gmd_valid_inv accepts verbose and emits message when TRUE", {
   expect_true("verbose" %in% names(formals(load_gmd_valid_inv)))
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -155,13 +182,18 @@ test_that("load_gmd_valid_inv accepts verbose and emits message when TRUE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_message(load_gmd_valid_inv(verbose = TRUE), regexp = "gmd_valid_inv")
+  expect_true(isTRUE(verbose_received))
 })
 
 test_that("load_gmd_valid_inv is silent when verbose = FALSE", {
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -171,14 +203,19 @@ test_that("load_gmd_valid_inv is silent when verbose = FALSE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_no_message(load_gmd_valid_inv(verbose = FALSE))
+  expect_false(isTRUE(verbose_received))
 })
 
 test_that("load_gmd_valid_log accepts verbose and emits message when TRUE", {
   expect_true("verbose" %in% names(formals(load_gmd_valid_log)))
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -188,16 +225,21 @@ test_that("load_gmd_valid_log accepts verbose and emits message when TRUE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_message(
     load_gmd_valid_log(verbose = TRUE),
     regexp = "dlw_validation_log"
   )
+  expect_true(isTRUE(verbose_received))
 })
 
 test_that("load_gmd_valid_log is silent when verbose = FALSE", {
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -207,14 +249,19 @@ test_that("load_gmd_valid_log is silent when verbose = FALSE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_no_message(load_gmd_valid_log(verbose = FALSE))
+  expect_false(isTRUE(verbose_received))
 })
 
 test_that("load_gmd_valid_report accepts verbose and emits message when TRUE", {
   expect_true("verbose" %in% names(formals(load_gmd_valid_report)))
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -224,16 +271,21 @@ test_that("load_gmd_valid_report accepts verbose and emits message when TRUE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_message(
     load_gmd_valid_report(verbose = TRUE),
     regexp = "validation_report"
   )
+  expect_true(isTRUE(verbose_received))
 })
 
 test_that("load_gmd_valid_report is silent when verbose = FALSE", {
+  verbose_received <- NULL
   local_mocked_bindings(
     get_pip_folders = function(...) "/fake/dir",
     .package = "pipfun"
@@ -243,10 +295,14 @@ test_that("load_gmd_valid_report is silent when verbose = FALSE", {
     .package = "stamp"
   )
   local_mocked_bindings(
-    pip_read = function(...) data.table(x = 1L),
+    pip_read = function(..., verbose = NULL) {
+      verbose_received <<- verbose
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   expect_no_message(load_gmd_valid_report(verbose = FALSE))
+  expect_false(isTRUE(verbose_received))
 })
 
 # -------------------------------------------------------------------------
@@ -260,8 +316,16 @@ test_that("pip_load_all_aux default verbose is getOption('pipload.verbose')", {
 })
 
 test_that("pip_load_all_aux verbose = FALSE silences the full loop (cascade check)", {
+  skip_if_not(has_pip_data())
+  calls_received <- list()
   local_mocked_bindings(
-    pip_load_aux = function(...) data.table(x = 1L),
+    pip_load_aux = function(measure, verbose, ...) {
+      calls_received[[length(calls_received) + 1]] <<- list(
+        measure = measure,
+        verbose = verbose
+      )
+      data.table(x = 1L)
+    },
     .package = "pipload"
   )
   local_mocked_bindings(
@@ -271,11 +335,27 @@ test_that("pip_load_all_aux verbose = FALSE silences the full loop (cascade chec
   expect_no_message(
     pip_load_all_aux(aux = c("cpi", "ppp"), verbose = FALSE, envir = new.env())
   )
+  # Verify pip_load_aux was called for both items with verbose = FALSE
+  expect_equal(length(calls_received), 2)
+  expect_true(all(vapply(
+    calls_received,
+    function(x) isFALSE(x$verbose),
+    logical(1)
+  )))
+  measures_called <- vapply(calls_received, function(x) x$measure, character(1))
+  expect_true("cpi" %in% measures_called)
+  expect_true("ppp" %in% measures_called)
 })
 
 test_that("pip_load_all_aux verbose = TRUE fires messages per aux item (cascade check)", {
+  skip_if_not(has_pip_data())
+  calls_received <- list()
   local_mocked_bindings(
     pip_load_aux = function(measure, verbose, ...) {
+      calls_received[[length(calls_received) + 1]] <<- list(
+        measure = measure,
+        verbose = verbose
+      )
       if (isTRUE(verbose)) {
         cli::cli_alert_info("loading {measure}")
       }
@@ -290,80 +370,14 @@ test_that("pip_load_all_aux verbose = TRUE fires messages per aux item (cascade 
   expect_message(
     pip_load_all_aux(aux = c("cpi", "ppp"), verbose = TRUE, envir = new.env())
   )
-})
-
-# -------------------------------------------------------------------------
-# pip_find_cache()
-# -------------------------------------------------------------------------
-
-test_that("pip_find_cache accepts verbose parameter", {
-  expect_true("verbose" %in% names(formals(pip_find_cache)))
-})
-
-test_that("pip_find_cache default verbose is getOption('pipload.verbose')", {
-  default_expr <- deparse(formals(pip_find_cache)$verbose)
-  expect_match(default_expr, "getOption")
-  expect_match(default_expr, "pipload.verbose")
-})
-
-test_that("pip_find_cache emits cli message when verbose = TRUE", {
-  local_mocked_bindings(
-    pip_load_cache_inventory = function(...) {
-      data.table(cache_id = c("ARG_2020_EH_INC_D1_PC", "BOL_2019_EH_CON_D1_PC"))
-    },
-    .package = "pipload"
-  )
-  expect_message(
-    pip_find_cache(verbose = TRUE),
-    regexp = "Found"
-  )
-})
-
-test_that("pip_find_cache is silent when verbose = FALSE", {
-  local_mocked_bindings(
-    pip_load_cache_inventory = function(...) {
-      data.table(cache_id = c("ARG_2020_EH_INC_D1_PC", "BOL_2019_EH_CON_D1_PC"))
-    },
-    .package = "pipload"
-  )
-  expect_no_message(pip_find_cache(verbose = FALSE))
-})
-
-# -------------------------------------------------------------------------
-# pip_load_dlw_inventory()
-# -------------------------------------------------------------------------
-
-test_that("pip_load_dlw_inventory accepts verbose parameter", {
-  expect_true("verbose" %in% names(formals(pip_load_dlw_inventory)))
-})
-
-test_that("pip_load_dlw_inventory default verbose is getOption('pipload.verbose')", {
-  default_expr <- deparse(formals(pip_load_dlw_inventory)$verbose)
-  expect_match(default_expr, "getOption")
-  expect_match(default_expr, "pipload.verbose")
-})
-
-test_that("pip_load_dlw_inventory emits message when verbose = TRUE", {
-  tmp <- withr::local_tempdir()
-  inv_dir <- file.path(tmp, "_Inventory")
-  dir.create(inv_dir, recursive = TRUE)
-  inv_file <- file.path(inv_dir, "dlw_inventory.fst")
-  fst::write_fst(data.frame(fullname = "ARG/data.qs2"), inv_file)
-
-  expect_message(
-    pip_load_dlw_inventory(root_dir = tmp, dlw_dir = tmp, verbose = TRUE),
-    regexp = "Loading"
-  )
-})
-
-test_that("pip_load_dlw_inventory is silent when verbose = FALSE", {
-  tmp <- withr::local_tempdir()
-  inv_dir <- file.path(tmp, "_Inventory")
-  dir.create(inv_dir, recursive = TRUE)
-  inv_file <- file.path(inv_dir, "dlw_inventory.fst")
-  fst::write_fst(data.frame(fullname = "ARG/data.qs2"), inv_file)
-
-  expect_no_message(
-    pip_load_dlw_inventory(root_dir = tmp, dlw_dir = tmp, verbose = FALSE)
-  )
+  # Verify pip_load_aux was called for both items with verbose = TRUE
+  expect_equal(length(calls_received), 2)
+  expect_true(all(vapply(
+    calls_received,
+    function(x) isTRUE(x$verbose),
+    logical(1)
+  )))
+  measures_called <- vapply(calls_received, function(x) x$measure, character(1))
+  expect_true("cpi" %in% measures_called)
+  expect_true("ppp" %in% measures_called)
 })

--- a/tests/testthat/test-verbose-arg.R
+++ b/tests/testthat/test-verbose-arg.R
@@ -1,0 +1,369 @@
+library(testthat)
+library(data.table)
+
+# -------------------------------------------------------------------------
+# pip_find_cache()
+# -------------------------------------------------------------------------
+
+test_that("pip_find_cache accepts verbose parameter", {
+  expect_true("verbose" %in% names(formals(pip_find_cache)))
+})
+
+test_that("pip_find_cache default verbose is getOption('pipload.verbose')", {
+  default_expr <- deparse(formals(pip_find_cache)$verbose)
+  expect_match(default_expr, "getOption")
+  expect_match(default_expr, "pipload.verbose")
+})
+
+test_that("pip_find_cache emits cli message when verbose = TRUE", {
+  local_mocked_bindings(
+    pip_load_cache_inventory = function(...) {
+      data.table(cache_id = c("ARG_2020_EH_INC_D1_PC", "BOL_2019_EH_CON_D1_PC"))
+    },
+    .package = "pipload"
+  )
+  expect_message(pip_find_cache(verbose = TRUE), regexp = "Found")
+})
+
+test_that("pip_find_cache is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    pip_load_cache_inventory = function(...) {
+      data.table(cache_id = c("ARG_2020_EH_INC_D1_PC", "BOL_2019_EH_CON_D1_PC"))
+    },
+    .package = "pipload"
+  )
+  expect_no_message(pip_find_cache(verbose = FALSE))
+})
+
+# -------------------------------------------------------------------------
+# pip_load_dlw_inventory()
+# -------------------------------------------------------------------------
+
+test_that("pip_load_dlw_inventory accepts verbose parameter", {
+  expect_true("verbose" %in% names(formals(pip_load_dlw_inventory)))
+})
+
+test_that("pip_load_dlw_inventory default verbose is getOption('pipload.verbose')", {
+  default_expr <- deparse(formals(pip_load_dlw_inventory)$verbose)
+  expect_match(default_expr, "getOption")
+  expect_match(default_expr, "pipload.verbose")
+})
+
+test_that("pip_load_dlw_inventory emits message when verbose = TRUE", {
+  tmp <- withr::local_tempdir()
+  inv_dir <- file.path(tmp, "_Inventory")
+  dir.create(inv_dir, recursive = TRUE)
+  inv_file <- file.path(inv_dir, "dlw_inventory.fst")
+  fst::write_fst(data.frame(fullname = "ARG/data.qs2"), inv_file)
+
+  expect_message(
+    pip_load_dlw_inventory(root_dir = tmp, dlw_dir = tmp, verbose = TRUE),
+    regexp = "Loading"
+  )
+})
+
+test_that("pip_load_dlw_inventory is silent when verbose = FALSE", {
+  tmp <- withr::local_tempdir()
+  inv_dir <- file.path(tmp, "_Inventory")
+  dir.create(inv_dir, recursive = TRUE)
+  inv_file <- file.path(inv_dir, "dlw_inventory.fst")
+  fst::write_fst(data.frame(fullname = "ARG/data.qs2"), inv_file)
+
+  expect_no_message(
+    pip_load_dlw_inventory(root_dir = tmp, dlw_dir = tmp, verbose = FALSE)
+  )
+})
+
+# -------------------------------------------------------------------------
+# Five zero-arg DLW loaders
+# -------------------------------------------------------------------------
+
+test_that("load_dlw_gmd_inventory accepts verbose and emits message when TRUE", {
+  expect_true("verbose" %in% names(formals(load_dlw_gmd_inventory)))
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_message(load_dlw_gmd_inventory(verbose = TRUE), regexp = "dlw_gmd_inv")
+})
+
+test_that("load_dlw_gmd_inventory is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_no_message(load_dlw_gmd_inventory(verbose = FALSE))
+})
+
+test_that("load_dlw_gmd_log accepts verbose and emits message when TRUE", {
+  expect_true("verbose" %in% names(formals(load_dlw_gmd_log)))
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_message(load_dlw_gmd_log(verbose = TRUE), regexp = "dlw_gmd_log")
+})
+
+test_that("load_dlw_gmd_log is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_no_message(load_dlw_gmd_log(verbose = FALSE))
+})
+
+test_that("load_gmd_valid_inv accepts verbose and emits message when TRUE", {
+  expect_true("verbose" %in% names(formals(load_gmd_valid_inv)))
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_message(load_gmd_valid_inv(verbose = TRUE), regexp = "gmd_valid_inv")
+})
+
+test_that("load_gmd_valid_inv is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_no_message(load_gmd_valid_inv(verbose = FALSE))
+})
+
+test_that("load_gmd_valid_log accepts verbose and emits message when TRUE", {
+  expect_true("verbose" %in% names(formals(load_gmd_valid_log)))
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_message(
+    load_gmd_valid_log(verbose = TRUE),
+    regexp = "dlw_validation_log"
+  )
+})
+
+test_that("load_gmd_valid_log is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_no_message(load_gmd_valid_log(verbose = FALSE))
+})
+
+test_that("load_gmd_valid_report accepts verbose and emits message when TRUE", {
+  expect_true("verbose" %in% names(formals(load_gmd_valid_report)))
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_message(
+    load_gmd_valid_report(verbose = TRUE),
+    regexp = "validation_report"
+  )
+})
+
+test_that("load_gmd_valid_report is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    get_pip_folders = function(...) "/fake/dir",
+    .package = "pipfun"
+  )
+  local_mocked_bindings(
+    st_alias_list = function() data.table(root = "/fake/dir", alias = "fake"),
+    .package = "stamp"
+  )
+  local_mocked_bindings(
+    pip_read = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  expect_no_message(load_gmd_valid_report(verbose = FALSE))
+})
+
+# -------------------------------------------------------------------------
+# pip_load_all_aux() — default alignment and cascade
+# -------------------------------------------------------------------------
+
+test_that("pip_load_all_aux default verbose is getOption('pipload.verbose')", {
+  default_expr <- deparse(formals(pip_load_all_aux)$verbose)
+  expect_match(default_expr, "getOption")
+  expect_match(default_expr, "pipload.verbose")
+})
+
+test_that("pip_load_all_aux verbose = FALSE silences the full loop (cascade check)", {
+  local_mocked_bindings(
+    pip_load_aux = function(...) data.table(x = 1L),
+    .package = "pipload"
+  )
+  local_mocked_bindings(
+    pip_add_aux_labels = function(dt, ...) dt,
+    .package = "pipload"
+  )
+  expect_no_message(
+    pip_load_all_aux(aux = c("cpi", "ppp"), verbose = FALSE, envir = new.env())
+  )
+})
+
+test_that("pip_load_all_aux verbose = TRUE fires messages per aux item (cascade check)", {
+  local_mocked_bindings(
+    pip_load_aux = function(measure, verbose, ...) {
+      if (isTRUE(verbose)) {
+        cli::cli_alert_info("loading {measure}")
+      }
+      data.table(x = 1L)
+    },
+    .package = "pipload"
+  )
+  local_mocked_bindings(
+    pip_add_aux_labels = function(dt, ...) dt,
+    .package = "pipload"
+  )
+  expect_message(
+    pip_load_all_aux(aux = c("cpi", "ppp"), verbose = TRUE, envir = new.env())
+  )
+})
+
+# -------------------------------------------------------------------------
+# pip_find_cache()
+# -------------------------------------------------------------------------
+
+test_that("pip_find_cache accepts verbose parameter", {
+  expect_true("verbose" %in% names(formals(pip_find_cache)))
+})
+
+test_that("pip_find_cache default verbose is getOption('pipload.verbose')", {
+  default_expr <- deparse(formals(pip_find_cache)$verbose)
+  expect_match(default_expr, "getOption")
+  expect_match(default_expr, "pipload.verbose")
+})
+
+test_that("pip_find_cache emits cli message when verbose = TRUE", {
+  local_mocked_bindings(
+    pip_load_cache_inventory = function(...) {
+      data.table(cache_id = c("ARG_2020_EH_INC_D1_PC", "BOL_2019_EH_CON_D1_PC"))
+    },
+    .package = "pipload"
+  )
+  expect_message(
+    pip_find_cache(verbose = TRUE),
+    regexp = "Found"
+  )
+})
+
+test_that("pip_find_cache is silent when verbose = FALSE", {
+  local_mocked_bindings(
+    pip_load_cache_inventory = function(...) {
+      data.table(cache_id = c("ARG_2020_EH_INC_D1_PC", "BOL_2019_EH_CON_D1_PC"))
+    },
+    .package = "pipload"
+  )
+  expect_no_message(pip_find_cache(verbose = FALSE))
+})
+
+# -------------------------------------------------------------------------
+# pip_load_dlw_inventory()
+# -------------------------------------------------------------------------
+
+test_that("pip_load_dlw_inventory accepts verbose parameter", {
+  expect_true("verbose" %in% names(formals(pip_load_dlw_inventory)))
+})
+
+test_that("pip_load_dlw_inventory default verbose is getOption('pipload.verbose')", {
+  default_expr <- deparse(formals(pip_load_dlw_inventory)$verbose)
+  expect_match(default_expr, "getOption")
+  expect_match(default_expr, "pipload.verbose")
+})
+
+test_that("pip_load_dlw_inventory emits message when verbose = TRUE", {
+  tmp <- withr::local_tempdir()
+  inv_dir <- file.path(tmp, "_Inventory")
+  dir.create(inv_dir, recursive = TRUE)
+  inv_file <- file.path(inv_dir, "dlw_inventory.fst")
+  fst::write_fst(data.frame(fullname = "ARG/data.qs2"), inv_file)
+
+  expect_message(
+    pip_load_dlw_inventory(root_dir = tmp, dlw_dir = tmp, verbose = TRUE),
+    regexp = "Loading"
+  )
+})
+
+test_that("pip_load_dlw_inventory is silent when verbose = FALSE", {
+  tmp <- withr::local_tempdir()
+  inv_dir <- file.path(tmp, "_Inventory")
+  dir.create(inv_dir, recursive = TRUE)
+  inv_file <- file.path(inv_dir, "dlw_inventory.fst")
+  fst::write_fst(data.frame(fullname = "ARG/data.qs2"), inv_file)
+
+  expect_no_message(
+    pip_load_dlw_inventory(root_dir = tmp, dlw_dir = tmp, verbose = FALSE)
+  )
+})


### PR DESCRIPTION
Fix the verbose in new pipeline data loaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/standardized an optional `verbose` parameter across key data-loading functions, defaulting to the global `pipload.verbose` option, including consistent message emission/suppression.
* **Tests**
  * Added coverage for `verbose` defaults and message behavior across loader functions; updated an integration test to skip when auxiliary data isn’t available.
* **Documentation**
  * Updated function usage docs for `verbose`.
  * Added planning/audit documentation for `verbose` standardization and R function-definition scanning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->